### PR TITLE
Pre-compute block matrix form of all used operators and store the matrices in `Expansion`

### DIFF
--- a/bench/bethe_gf/bethe_gf.jl
+++ b/bench/bethe_gf/bethe_gf.jl
@@ -33,7 +33,7 @@ using Keldysh; kd = Keldysh
 using KeldyshED; ked = KeldyshED; op = KeldyshED.Operators;
 
 using QInchworm.ppgf: normalize!, density_matrix
-using QInchworm.expansion: Expansion, InteractionPair
+using QInchworm.expansion: Expansion, InteractionPair, add_corr_operators!
 using QInchworm.inchworm: inchworm!, correlator_2p
 using QInchworm.mpi: ismaster
 
@@ -198,7 +198,7 @@ function run_hubbard_dimer(ntau, orders, orders_bare, orders_gf, N_samples)
         @show diff_exa
     end
 
-    push!(expansion.corr_operators, (op.c(1), op.c_dag(1)))
+    add_corr_operators!(expansion, (op.c(1), op.c_dag(1)))
     g = -correlator_2p(expansion, grid, orders_gf, N_samples)
 
     if false

--- a/bench/bethe_gf_convergence/bethe_gf_convergence.jl
+++ b/bench/bethe_gf_convergence/bethe_gf_convergence.jl
@@ -21,7 +21,7 @@ using Keldysh; kd = Keldysh
 using KeldyshED; ked = KeldyshED; op = KeldyshED.Operators;
 
 using QInchworm.ppgf: normalize!, density_matrix
-using QInchworm.expansion: Expansion, InteractionPair
+using QInchworm.expansion: Expansion, InteractionPair, add_corr_operators!
 using QInchworm.inchworm: inchworm_matsubara!, correlator_2p
 using QInchworm.mpi: ismaster
 
@@ -97,7 +97,7 @@ function run_bethe(ntau, orders, orders_bare, orders_gf, N_samples, n_pts_after_
                         n_pts_after_max=n_pts_after_max)
     normalize!(expansion.P, β)
 
-    push!(expansion.corr_operators, (op.c(1), op.c_dag(1)))
+    add_corr_operators!(expansion, (op.c(1), op.c_dag(1)))
     g = correlator_2p(expansion, grid, orders_gf, N_samples)
 
     # ==

--- a/src/inchworm.jl
+++ b/src/inchworm.jl
@@ -26,7 +26,6 @@ using QInchworm.configuration: Configuration,
                                set_final_node_time!,
                                set_inchworm_node_time!,
                                set_operator_node_time!,
-                               operator,
                                sector_block_matrix_from_ppgf
 using QInchworm.configuration: Node, InchNode, OperatorNode
 

--- a/src/sector_block_matrix.jl
+++ b/src/sector_block_matrix.jl
@@ -16,6 +16,21 @@ const SectorBlockMatrix = Dict{Int64, Tuple{Int64, Matrix{ComplexF64}}}
 """
 $(TYPEDSIGNATURES)
 
+Returns the [`SectorBlockMatrix`](@ref) representation of the many-body operator.
+"""
+function operator_to_sector_block_matrix(ed::KeldyshED.EDCore,
+                                         op::KeldyshED.OperatorExpr)::SectorBlockMatrix
+    sbm = SectorBlockMatrix()
+    op_blocks = KeldyshED.operator_blocks(ed, op)
+    for ((s_f, s_i), mat) in op_blocks
+        sbm[s_i] = (s_f, mat)
+    end
+    sbm
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Construct a block-diagonal complex matrix, whose block structure is consistent
 with the invariant subspace partition of a given KeldyshED.EDCore object.
 All matrix elements of the stored blocks are set to zero.

--- a/test/bethe_gf.jl
+++ b/test/bethe_gf.jl
@@ -30,7 +30,7 @@ using Keldysh; kd = Keldysh
 using KeldyshED; ked = KeldyshED; op = KeldyshED.Operators;
 
 using QInchworm.ppgf: normalize!, density_matrix
-using QInchworm.expansion: Expansion, InteractionPair
+using QInchworm.expansion: Expansion, InteractionPair, add_corr_operators!
 using QInchworm.inchworm: inchworm!, correlator_2p
 using QInchworm.mpi: ismaster
 
@@ -121,7 +121,7 @@ using QInchworm.mpi: ismaster
             @show diff_exa
         end
 
-        push!(expansion.corr_operators, (op.c(1), op.c_dag(1)))
+        add_corr_operators!(expansion, (op.c(1), op.c_dag(1)))
         g = -correlator_2p(expansion, grid, orders_gf, N_samples)
 
         diff_g_nca = maximum(abs.(g_nca - g[1].mat.data[1, 1, :]))

--- a/test/inchworm.jl
+++ b/test/inchworm.jl
@@ -5,7 +5,7 @@ using KeldyshED; ked = KeldyshED; op = KeldyshED.Operators;
 
 using QInchworm.spline_gf: SplineInterpolatedGF
 
-using QInchworm.expansion: Expansion, InteractionPair
+using QInchworm.expansion: Expansion, InteractionPair, add_corr_operators!
 using QInchworm.topology_eval: get_topologies_at_order,
                                get_diagrams_at_order,
                                get_configurations_and_diagrams
@@ -170,7 +170,7 @@ end
 
     # -- Single-particle GF
 
-    push!(expansion.corr_operators, (op.c("0"), op.c_dag("0")))
+    add_corr_operators!(expansion, (op.c("0"), op.c_dag("0")))
     g = -correlator_2p(expansion, grid, orders, N_samples)
 
     @show g


### PR DESCRIPTION
It is now neccessary to add operators used by `correlator_2p()` by calling a new function `add_corr_operators!(::Expansion, ::Tuple{Operator, Operator})`.

**Update:** Here are timings of some unit tests measured with and w/o this patch applied.
```
                 dimer    hubbard_dimer     bethe     bethe_gf
                 =====    =============     =====     ========
main             28.9s    4.4s              2m28.9s   58.0s
precompute_mats  28.0s    2.3s              1m26.5s   39.1s
```